### PR TITLE
Points index.js at right file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./colorbrewer.js');
+module.exports = require('./cartocolor');


### PR DESCRIPTION
It was left set at `colorbrewer.js` and browserify wasn't resolving the dependency.
