### PR TITLE
Add PurpOr first interval

### DIFF
--- a/cartocolor.js
+++ b/cartocolor.js
@@ -662,6 +662,10 @@ var cartocolor = {
         ]
     },
     "PurpOr": {
+        "2": [
+            "#f9ddda",
+            "#573b88"
+        ],
         "3": [
             "#f9ddda",
             "#ce78b3",


### PR DESCRIPTION
Hi @makella, just found a small bug in the PurpOr palette.

Related to https://github.com/CartoDB/cartoframes/issues/1382.