### PR TITLE
Add license entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "browserify"
   ],
   "homepage": "http://cartodb.com/",
+  "license": "CC-BY-3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/cartodb/cartocolor"


### PR DESCRIPTION
Adding an explicit license entry to make this information more visible in your npm page, where the license is currently displayed as "none", as well as easier to automatically identify and validate by license compliance tools.