### PR TITLE
fix: Fix typo in palette names, replace 1 with l

### DIFF
--- a/src/carto.js
+++ b/src/carto.js
@@ -16,7 +16,7 @@ export const Burg = {
   tags: ["quantitative"],
 };
 
-export const BurgY1 = {
+export const BurgYl = {
   2: ["#fbe6c5", "#70284a"],
   3: ["#fbe6c5", "#dc7176", "#70284a"],
   4: ["#fbe6c5", "#ee8a82", "#c8586c", "#70284a"],
@@ -88,7 +88,7 @@ export const Peach = {
   tags: ["quantitative"],
 };
 
-export const PinkY1 = {
+export const PinkYl = {
   2: ["#fef6b5", "#e15383"],
   3: ["#fef6b5", "#ffa679", "#e15383"],
   4: ["#fef6b5", "#ffc285", "#fa8a76", "#e15383"],
@@ -178,7 +178,7 @@ export const Emrld = {
   tags: ["quantitative"],
 };
 
-export const ag_GrnY1 = {
+export const ag_GrnYl = {
   2: ["#245668", "#EDEF5D"],
   3: ["#245668", "#39AB7E", "#EDEF5D"],
   4: ["#245668", "#0D8F81", "#6EC574", "#EDEF5D"],
@@ -196,7 +196,7 @@ export const ag_GrnY1 = {
   tags: ["aggregation"],
 };
 
-export const BluY1 = {
+export const BluYl = {
   2: ["#f7feae", "#045275"],
   3: ["#f7feae", "#46aea0", "#045275"],
   4: ["#f7feae", "#7ccba2", "#089099", "#045275"],
@@ -358,7 +358,7 @@ export const ag_Sunset = {
   tags: ["aggregation"],
 };
 
-export const BrwnY1 = {
+export const BrwnYl = {
   2: ["#ede5cf", "#541f3f"],
   3: ["#ede5cf", "#c1766f", "#541f3f"],
   4: ["#ede5cf", "#d39c83", "#a65461", "#541f3f"],

--- a/test/cartocolor.test.js
+++ b/test/cartocolor.test.js
@@ -1,30 +1,80 @@
-import { deepEqual } from 'node:assert/strict';
-import * as cartocolor from '../dist/cartocolor.js';
-import colorbrewer from 'colorbrewer';
+import { deepEqual } from "node:assert/strict";
+import * as cartocolor from "../dist/cartocolor.js";
+import colorbrewer from "colorbrewer";
 
 const { Teal, Safe, cb_Greys } = cartocolor;
 
 // Validate CARTO "Teal" palette.
-deepEqual(Object.keys(Teal), ['2', '3', '4', '5', '6', '7', 'tags'], "Teal");
-deepEqual(Teal['2'], ['#d1eeea','#2a5674'], 'Teal#2');
-deepEqual(Teal['tags'], ['quantitative'], 'Teal#tags');
+deepEqual(Object.keys(Teal), ["2", "3", "4", "5", "6", "7", "tags"], "Teal");
+deepEqual(Teal["2"], ["#d1eeea", "#2a5674"], "Teal#2");
+deepEqual(Teal["tags"], ["quantitative"], "Teal#tags");
 
 // Validate CARTO "Safe" palette.
-deepEqual(Object.keys(Safe), ['2', '3', '4', '5', '6', '7', '8', '9', '10', '11', 'tags'], "Safe");
-deepEqual(Safe['2'], ['#88CCEE','#CC6677', '#888888'], 'Safe#2');
-deepEqual(Safe['tags'], ['qualitative', 'colorblind'], 'Safe#tags');
+deepEqual(
+  Object.keys(Safe),
+  ["2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "tags"],
+  "Safe",
+);
+deepEqual(Safe["2"], ["#88CCEE", "#CC6677", "#888888"], "Safe#2");
+deepEqual(Safe["tags"], ["qualitative", "colorblind"], "Safe#tags");
 
 // Validate augmented ColorBrewer "Greys" palette.
-deepEqual(Object.keys(cb_Greys), ['3', '4', '5', '6', '7', '8', '9', 'tags'], "cb_Greys");
-deepEqual(cb_Greys['3'], ['#f0f0f0', '#bdbdbd', '#636363'], 'cb_Greys#3');
-deepEqual(cb_Greys['tags'], ['quantitative'], 'cb_Greys#tags');
+deepEqual(
+  Object.keys(cb_Greys),
+  ["3", "4", "5", "6", "7", "8", "9", "tags"],
+  "cb_Greys",
+);
+deepEqual(cb_Greys["3"], ["#f0f0f0", "#bdbdbd", "#636363"], "cb_Greys#3");
+deepEqual(cb_Greys["tags"], ["quantitative"], "cb_Greys#tags");
 
-// Confirm that all colorbrewer palettes are augmented.
-const keysImported = Object.keys(colorbrewer)
-  .filter((key) => key !== 'schemeGroups')
+// Exports: CARTO
+const cartoKeysExpected = [
+  "Burg",
+  "BurgYl",
+  "RedOr",
+  "OrYel",
+  "Peach",
+  "PinkYl",
+  "Mint",
+  "BluGrn",
+  "DarkMint",
+  "Emrld",
+  "ag_GrnYl",
+  "BluYl",
+  "Teal",
+  "TealGrn",
+  "Purp",
+  "PurpOr",
+  "Sunset",
+  "Magenta",
+  "SunsetDark",
+  "ag_Sunset",
+  "BrwnYl",
+  "ArmyRose",
+  "Fall",
+  "Geyser",
+  "Temps",
+  "TealRose",
+  "Tropic",
+  "Earth",
+  "Antique",
+  "Bold",
+  "Pastel",
+  "Prism",
+  "Safe",
+  "Vivid",
+].sort();
+const cartoKeysExported = Object.keys(cartocolor)
+  .filter((key) => !key.startsWith("cb_"))
   .sort();
-const keysExported = Object.keys(cartocolor)
-  .filter((key) => key.startsWith('cb_'))
-  .map((key) => key.replace(/^cb_/, ''))
+deepEqual(cartoKeysExported, cartoKeysExpected, "carto exports");
+
+// Exports: Colorbrewer
+const cbKeysExpected = Object.keys(colorbrewer)
+  .filter((key) => key !== "schemeGroups")
   .sort();
-deepEqual(keysExported, keysImported, 'augments all palettes in colorbrewer');
+const cbKeysExported = Object.keys(cartocolor)
+  .filter((key) => key.startsWith("cb_"))
+  .map((key) => key.replace(/^cb_/, ""))
+  .sort();
+deepEqual(cbKeysExported, cbKeysExpected, "colorbrewer exports");


### PR DESCRIPTION
I accidentally renamed several palettes in the v5.0 release with https://github.com/CartoDB/CartoColor/pull/46. Several original palettes used `Yl` (last character is a lowercase L) which I misread as `Y1` (last character is digit 'one'). This PR fixes the mistake, and adds a unit test to check that all original exports from v4 are present in v5.

To be published in a v5.0.x patch release.